### PR TITLE
compat: Match Base @inferred TypeEgal result checks

### DIFF
--- a/src/testinferred.jl
+++ b/src/testinferred.jl
@@ -255,6 +255,7 @@ function _testinferred(ex, orig_ex, mod, src, allow = :(Union{}); constprop = fa
     end
 
     inftype = esc(gensym())
+    infsplit = esc(gensym())
     rettype = esc(gensym())
     result = esc(gensym())
     main = quote
@@ -271,9 +272,11 @@ function _testinferred(ex, orig_ex, mod, src, allow = :(Union{}); constprop = fa
                     @__MODULE__
                 )
             )
-            $rettype = $result isa Type ? Type{$result} : typeof($result)
+            $rettype = Core.Typeof($result)
+            $infsplit = typesplit($inftype, $(esc(allow)))
             v = $rettype <: $(esc(allow)) ||
-                $rettype == typesplit($inftype, $(esc(allow)))
+                $rettype == $infsplit ||
+                ($result isa Type && Type{$result} == $infsplit)
             testresult = Returned(
                 v, Expr(:call, :!=, $rettype, $inftype),
                 $(QuoteNode(src))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,8 @@ using Test
     x = 3.0
     @constinferred mysqrt(x; complex=false)
     @constinferred_broken mysqrt(x; complex=true)
+    return_type_object() = Float64
+    @test @constinferred(return_type_object()) === Float64
     complex = false
     @constinferred_broken mysqrt(x; complex)
     @constinferred_broken mysqrt(x; complex = complex)


### PR DESCRIPTION
The Base PR JuliaLang/julia#62001 is expected to spell exact closed type-object inference results as Core.TypeEgal. Match Base Test's @inferred comparison logic by comparing Core.Typeof(result) with the inferred result after typesplit, including the existing type-valued result fallback.

AI disclosure: This commit was prepared with assistance from generative AI. The resulting PR should be checked carefully by a maintainer before merging.